### PR TITLE
fix: update section status if page has no block

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -270,6 +270,7 @@ export async function loadBlock(block, eager = false) {
  * @param {Element} $main The container element
  */
 export async function loadBlocks($main) {
+  updateSectionsStatus($main);
   const blocks = [...$main.querySelectorAll('div.block')];
   for (let i = 0; i < blocks.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
https://no-blocks--helix-project-boilerplate--adobe.hlx3.page/default-content-examples

vs. 

https://main--helix-project-boilerplate--adobe.hlx3.page/default-content-examples