### PR TITLE
feat: block-wrapper

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -146,7 +146,7 @@ export function decorateBlock(block) {
  * Decorates all sections in a container element.
  * @param {Element} $main The container element
  */
-function decorateSections($main) {
+export function decorateSections($main) {
   $main.querySelectorAll(':scope > div').forEach((section) => {
     const wrappers = [];
     let defaultContent = false;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -116,24 +116,6 @@ export function toClassName(name) {
 }
 
 /**
- * Wraps each section in an additional {@code div}.
- * @param {[Element]} $sections The sections
- */
-function wrapSections($sections) {
-  $sections.forEach(($div) => {
-    if ($div.childNodes.length === 0) {
-      // remove empty sections
-      $div.remove();
-    } else if (!$div.id) {
-      const $wrapper = document.createElement('div');
-      $wrapper.className = 'section-wrapper';
-      $div.parentNode.appendChild($wrapper);
-      $wrapper.appendChild($div);
-    }
-  });
-}
-
-/**
  * Decorates a block.
  * @param {Element} block The block element
  */
@@ -142,7 +124,7 @@ export function decorateBlock(block) {
   const classes = Array.from(block.classList.values());
   const blockName = classes[0];
   if (!blockName) return;
-  const section = block.closest('.section-wrapper');
+  const section = block.closest('.section');
   if (section) {
     section.classList.add(`${blockName}-container`.replace(/--/g, '-'));
   }
@@ -155,25 +137,38 @@ export function decorateBlock(block) {
   block.classList.add('block');
   block.setAttribute('data-block-name', shortBlockName);
   block.setAttribute('data-block-status', 'initialized');
+
+  const blockWrapper = block.parentElement;
+  blockWrapper.classList.add(`${shortBlockName}-wrapper`);
 }
 
 /**
  * Decorates all sections in a container element.
  * @param {Element} $main The container element
  */
-export function decorateSections($main) {
-  wrapSections($main.querySelectorAll(':scope > div'));
-  $main.querySelectorAll(':scope > div.section-wrapper').forEach((section) => {
+function decorateSections($main) {
+  $main.querySelectorAll(':scope > div').forEach((section) => {
+    const wrappers = [];
+    let defaultContent = false;
+    [...section.children].forEach((e) => {
+      if (e.tagName === 'DIV' || !defaultContent) {
+        const wrapper = document.createElement('div');
+        wrappers.push(wrapper);
+        defaultContent = e.tagName !== 'DIV';
+      }
+      wrappers[wrappers.length - 1].append(e);
+    });
+    wrappers.forEach((wrapper) => section.append(wrapper));
+    section.classList.add('section');
     section.setAttribute('data-section-status', 'initialized');
   });
 }
-
 /**
  * Updates all section status in a container element.
  * @param {Element} $main The container element
  */
 export function updateSectionsStatus($main) {
-  const sections = [...$main.querySelectorAll(':scope > div.section-wrapper')];
+  const sections = [...$main.querySelectorAll(':scope > div.section')];
   for (let i = 0; i < sections.length; i += 1) {
     const section = sections[i];
     const status = section.getAttribute('data-section-status');
@@ -195,7 +190,7 @@ export function updateSectionsStatus($main) {
  */
 export function decorateBlocks($main) {
   $main
-    .querySelectorAll('div.section-wrapper > div > div')
+    .querySelectorAll('div.section > div > div')
     .forEach(($block) => decorateBlock($block));
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -116,7 +116,7 @@ main input:hover {
   border: 1px solid rgba(var(--text-color),0.9);
 }
 
-main .section-wrapper {
+main .section {
   padding: 0 2rem; 
 }
 
@@ -194,7 +194,7 @@ main img {
   main {
     min-height: calc(100vh - 212px);
   }
-  main>.section-wrapper>div {
+  main>.section>div {
       max-width: 30em;
       margin: auto;
   }    
@@ -202,7 +202,7 @@ main img {
 
 /* above the fold CSS goes here to squash CLS */
 
-main .section-wrapper[data-section-status='loading'], main .section-wrapper[data-section-status='initialized'] {
+main .section[data-section-status='loading'], main .section[data-section-status='initialized'] {
     display: none;
   }
   

--- a/test/blocks/example/block.html
+++ b/test/blocks/example/block.html
@@ -1,5 +1,5 @@
 <main>
-    <div class="section-wrapper">
+    <div class="section">
         <div>
             <div class="example">
                 <div>

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -138,7 +138,7 @@ describe('Core Helix features', () => {
 describe('Sections and blocks', () => {
   it('Decorates sections', async () => {
     scripts.decorateSections(document.querySelector('main'));
-    expect(document.querySelectorAll('main .section').length).to.equal(1);
+    expect(document.querySelectorAll('main .section').length).to.equal(2);
   });
 
   it('Decorates blocks', async () => {

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -138,7 +138,7 @@ describe('Core Helix features', () => {
 describe('Sections and blocks', () => {
   it('Decorates sections', async () => {
     scripts.decorateSections(document.querySelector('main'));
-    expect(document.querySelectorAll('main .section-wrapper').length).to.equal(1);
+    expect(document.querySelectorAll('main .section').length).to.equal(1);
   });
 
   it('Decorates blocks', async () => {
@@ -155,12 +155,12 @@ describe('Sections and blocks', () => {
 
   it('Updates section status', async () => {
     scripts.updateSectionsStatus(document.querySelector('main'));
-    document.querySelectorAll('main .section-wrapper').forEach(($section) => {
+    document.querySelectorAll('main .section').forEach(($section) => {
       expect($section.dataset.sectionStatus).to.equal('loaded');
     });
 
     // test section with block still loading
-    const $section = document.querySelector('main .section-wrapper');
+    const $section = document.querySelector('main .section');
     delete $section.dataset.sectionStatus;
     $section.querySelector(':scope .block').dataset.blockStatus = 'loading';
     scripts.updateSectionsStatus(document.querySelector('main'));
@@ -168,7 +168,7 @@ describe('Sections and blocks', () => {
   });
 
   it('Reads block config', async () => {
-    document.querySelector('main .section-wrapper > div').innerHTML += await readFile({ path: './config.html' });
+    document.querySelector('main .section > div').innerHTML += await readFile({ path: './config.html' });
     const cfg = scripts.readBlockConfig(document.querySelector('main .config'));
     expect(cfg).to.deep.include({
       'prop-0': 'Plain text',


### PR DESCRIPTION
https://block-wrapper--helix-project-boilerplate--adobe.hlx3.page/

vs.

https://main--helix-project-boilerplate--adobe.hlx3.page/

i think we often run into the situation, where a block requires a different `max-width` or `background` from the default content or other blocks.
 
in the past, i usually split them off into different sections to achieve that, which i realized recently is not the best solution as it removes the information about the section boundary.
i noticed that we had a concept that we had in the existing DOM that could help with that. 

in the current main branch we have a DOM that looks as follows...

<img width="552" alt="Screen Shot 2022-01-31 at 5 22 29 PM" src="https://user-images.githubusercontent.com/5289336/151894563-d51c6a3c-4758-4cdb-903f-c5a90156116c.png">

there is a somewhat underutilized `<div>` below the `.section-wrapper` that we usually use for the `max-width` of default content and blocks in a section.

if we break this up and group default content and individual blocks to something that looks more like this...
<img width="553" alt="Screen Shot 2022-01-31 at 5 25 01 PM" src="https://user-images.githubusercontent.com/5289336/151894794-445bc2f1-3d6d-4cc8-977e-59f3959893ce.png">
...it allows for a lot more precise control on a per block basis, when it comes to `max-width` or `background`.

this change doesn't really make too much of a difference to any `CSS` rules that i have found but allowed me to implement relatively complex width/background logic with just CSS, not having to resort to sections either through authoring or auto sections for certain blocks...

<img width="366" alt="Screen Shot 2022-01-31 at 5 28 39 PM" src="https://user-images.githubusercontent.com/5289336/151895100-1eb77afa-4643-4849-98e6-05eb4578aac9.png">

... retroactively, i think this would have made the code much simpler in many projects, and would also have kept the `section` metaphor a lot cleaner in places where we want to group blocks and default content, without being forced to sacrifice that grouping because of layout (`width` & `background`) changes.

when pulling together the PR, i realized the `.section-wrapper` class doesn't make any sense in that construct, as the `<div>` really is the `section` div, so i renamed that, which produces a bit of backwards compatibility issue, however it turns out that that one is very easy to fix with a simple search and replace of `section-wrapper` to `section` across a projects code base.

let me know what you think...