### PR TITLE
chore: safari img loading suppression

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -340,10 +340,10 @@ export function createOptimizedPicture(src, alt = '', eager = false, breakpoints
       picture.appendChild(source);
     } else {
       const img = document.createElement('img');
-      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
       img.setAttribute('loading', eager ? 'eager' : 'lazy');
       img.setAttribute('alt', alt);
       picture.appendChild(img);
+      img.setAttribute('src', `${pathname}?width=${br.width}&format=${ext}&optimize=medium`);
     }
   });
 


### PR DESCRIPTION
https://safari-img-loading--helix-project-boilerplate--adobe.hlx.live/

vs. 

https://main--helix-project-boilerplate--adobe.hlx.live/

safari (surprisingly, at least to me) still doesn't support `loading="lazy"` and as a side effect of that feels compelled to load every `img` element (even if it is not attached to the DOM yet) as soon as the `src` attribute is set, which means that the fallback `jpg`/`png` images are always loaded. setting the `src` attribute after attaching the `img` element to containing `picture` element seems to fix that.

<img width="991" alt="Screen Shot 2022-02-04 at 11 25 35 AM" src="https://user-images.githubusercontent.com/5289336/152583844-f79472cd-94a7-4178-bff4-3d0dd694a93a.png">

<img width="991" alt="Screen Shot 2022-02-04 at 11 26 29 AM" src="https://user-images.githubusercontent.com/5289336/152583840-41bfba65-376a-4764-912b-ba6f1045d80c.png">

