### PR TITLE
feat: protect against lazy lcp candidates

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -425,6 +425,7 @@ async function waitForLCP() {
   const lcpCandidate = document.querySelector('main img');
   await new Promise((resolve) => {
     if (lcpCandidate && !lcpCandidate.complete) {
+      lcpCandidate.setAttribute('loading', 'eager');
       lcpCandidate.addEventListener('load', () => resolve());
       lcpCandidate.addEventListener('error', () => resolve());
     } else {


### PR DESCRIPTION
https://eager-lcp--helix-project-boilerplate--adobe.hlx.live/

vs. 

https://main--helix-project-boilerplate--adobe.hlx.live/

there are circumstances where the lcp (eg. if it is calculated or selected by an lcp block) ends up being an image that's loaded `lazy`, which will hang the lcp promise because the containing section will still be hidden.

there is really no good reason for something that we identify as the lcpCandidate to ever not be `eager` loaded, so setting the `loading` in the block loader makes it a little bit less error prone for the block developer.
