### PR TITLE
chore: add json to codebus

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -2,4 +2,6 @@
 *.md
 karma.config.js
 LICENSE
+package.json
+package-lock.json
 test/*

--- a/.hlxignore
+++ b/.hlxignore
@@ -1,6 +1,5 @@
 .*
 *.md
-*.json
 karma.config.js
 LICENSE
 test/*


### PR DESCRIPTION
not sure why we excluded all `.json`, maybe because of the `.json`s in the root?