### PR TITLE
fix: display tools in nav ribbon instead of overflow

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -2,8 +2,8 @@
 header nav {
   display: grid;
   grid-template:
-    "hamburger brand" var(--nav-height)
-    "sections sections" 1fr / 50px 1fr;
+    'hamburger brand tools' var(--nav-height)
+    'sections sections sections' 1fr / 50px 1fr 50px;
   align-items: center;
   padding: 0 2rem;
   position: fixed;
@@ -66,7 +66,7 @@ header nav[aria-expanded='false'] .nav-hamburger-icon::before {
 
 header nav[aria-expanded='false'] .nav-hamburger-icon::after,
 header nav[aria-expanded='false'] .nav-hamburger-icon::before {
-  content: "";
+  content: '';
   position: absolute;
   top: -6px;
 }
@@ -88,7 +88,7 @@ header nav[aria-expanded='true'] .nav-hamburger-icon {
 
 header nav[aria-expanded='true'] .nav-hamburger-icon::after,
 header nav[aria-expanded='true'] .nav-hamburger-icon::before {
-  content: "";
+  content: '';
   display: block;
   box-sizing: border-box;
   position: absolute;
@@ -132,10 +132,10 @@ header nav[aria-expanded='true'] .nav-sections {
 }
 
 /* tools */
-
 header nav .nav-tools {
   grid-area: tools;
   flex: 0 0 auto;
+  height: 22px;
 }
 
 header nav .nav-tools p {
@@ -154,7 +154,6 @@ header nav[aria-expanded='true'] .nav-tools ul {
 header nav[aria-expanded='true'] .nav-tools li {
   padding: 0;
 }
-
 
 /* desktop nav styles */
 @media (min-width: 1000px) {


### PR DESCRIPTION
nav tools overflow nav height

before (tools overhang hero):
<img width="962" alt="Screen Shot 2022-05-17 at 3 15 08 PM" src="https://user-images.githubusercontent.com/43383503/168911267-ee563035-2598-47f1-8b55-be0c2f54d2e3.png">

after (tools in nav bar):
<img width="981" alt="Screen Shot 2022-05-17 at 3 16 00 PM" src="https://user-images.githubusercontent.com/43383503/168911397-1817a332-149f-4526-8df5-892746461f85.png">

Fixes #92 

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After: https://nav-tools-display--helix-project-boilerplate--adobe.hlx.page/
