### PR TITLE
feat: getMetadata can return multiple values

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -87,12 +87,12 @@ export function loadCSS(href, callback) {
 /**
  * Retrieves the content of a metadata tag.
  * @param {string} name The metadata name (or property)
- * @returns {string} The metadata value
+ * @returns {string} The metadata value(s)
  */
 export function getMetadata(name) {
   const attr = name && name.includes(':') ? 'property' : 'name';
-  const meta = document.head.querySelector(`meta[${attr}="${name}"]`);
-  return meta && meta.content;
+  const meta = [...document.head.querySelectorAll(`meta[${attr}="${name}"]`)].map((m) => m.content).join(', ');
+  return meta || null;
 }
 
 /**


### PR DESCRIPTION
current `getMetadata()` behavior is to return the `content` of the first matching meta tag or `null` if no tag is found
propose `getMetadata()` to return the `content` of _all_ matching meta tags (returning comma-separated string if there is more than one matching meta tag) or `null` if no tag(s) are found

current behavior:
<img width="727" alt="Screen Shot 2022-05-17 at 4 18 41 PM" src="https://user-images.githubusercontent.com/43383503/168921606-dcdbdca9-35c4-425e-8810-cc0374b293ed.png">

proposed behavior:
<img width="726" alt="Screen Shot 2022-05-17 at 4 19 43 PM" src="https://user-images.githubusercontent.com/43383503/168921755-972ac7dd-54f4-4ad7-b51b-09bc28c1f171.png">


Fix #78 

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After: https://multiple-meta-tags--helix-project-boilerplate--adobe.hlx.page/
