### PR TITLE
fix: description added twice to index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -37,10 +37,6 @@ indices:
         select: head > meta[name="topics"]
         value: |
           attribute(el, 'content')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
       lastModified:
         select: none
         value: |


### PR DESCRIPTION
Description property is listed twice to helix-query.yaml. 