### PR TITLE
feat(404): add rum instrumentation

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <title>Page not found</title>
   <script type="text/javascript">
@@ -9,7 +10,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
   <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-  <script>
+  <script type="module">
+    import { sampleRUM } from '/scripts/scripts.js';
+
     window.addEventListener('load', () => {
       if (document.referrer) {
         const { origin, pathname } = new URL(document.referrer);
@@ -23,6 +26,7 @@
           btnContainer.append(backBtn);
         }
       }
+      sampleRUM('404', { source: document.referrer, target: window.location.href });
     });
   </script>
   <link rel="stylesheet" href="/styles/styles.css">
@@ -43,6 +47,7 @@
   </style>
   <link rel="stylesheet" href="/styles/lazy-styles.css">
 </head>
+
 <body>
   <header></header>
   <main class="error">
@@ -58,4 +63,5 @@
   </main>
   <footer></footer>
 </body>
+
 </html>


### PR DESCRIPTION
This is an extension of #99 and adds some RUM instrumentation to the error page, so that we can later on generate reports on pages that are missing and pages that have likely broken links.

checkpoint is `404` (not `error`, so that we can distinguish it from a JS error). `source` is the referrer and `target` the current URL

Test URLs:
- Before: https://404--helix-project-boilerplate--adobe.hlx.page/error?rum=on
- After: https://404-rum--helix-project-boilerplate--adobe.hlx.page/error?rum=on
