### PR TITLE
block config img support

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -223,6 +223,13 @@ export function readBlockConfig(block) {
           } else {
             value = as.map((a) => a.href);
           }
+        } else if (col.querySelector('img')) {
+          const imgs = [...col.querySelectorAll('img')];
+          if (imgs.length === 1) {
+            value = imgs[0].src;
+          } else {
+            value = imgs.map((img) => img.src);
+          }
         } else if (col.querySelector('p')) {
           const ps = [...col.querySelectorAll('p')];
           if (ps.length === 1) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -273,7 +273,7 @@ export function decorateSections($main) {
       const keys = Object.keys(meta);
       keys.forEach((key) => {
         if (key === 'style') section.classList.add(toClassName(meta.style));
-        else section.dataset[key] = meta[key];
+        else section.dataset[toCamelCase(key)] = meta[key];
       });
       sectionMeta.remove();
     }


### PR DESCRIPTION
while adding image support to `readBlockConfig` i also realized that there was a bug using kebob-case instead of camelCase for the dataset name...

compare:

https://block-config-img-support--helix-project-boilerplate--adobe.hlx.page/drafts/uncled/
vs.
https://main--helix-project-boilerplate--adobe.hlx.page/drafts/uncled/


<img width="874" alt="Screen Shot 2022-06-17 at 10 53 36 AM" src="https://user-images.githubusercontent.com/5289336/174352142-c1724db9-e26f-41a4-bd23-1384a813da9f.png">

to see the changes beyond the obvious fix, you have to inspect the attributes of the highlighted section.