### PR TITLE
chore: use heading font

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -62,6 +62,7 @@ header {
 
 h1, h2, h3,
 h4, h5, h6 {
+  font-family: var(--heading-font-family);
   font-weight: 600;
   line-height: 1.25;
   margin-top: 1em;


### PR DESCRIPTION
https://main--helix-project-boilerplate--adobe.hlx.page/

vs.

https://heading-font--helix-project-boilerplate--adobe.hlx.page/
