### PR TITLE
feat(rum): add advanced rum tracking

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -640,17 +640,17 @@ const ICON_ROOT = '/icons';
 sampleRUM('top');
 
 window.addEventListener('unhandledrejection', (event) => {
-      sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line })
+      sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });
 });
 
 window.addEventListener('error', (event) => {
-      sampleRUM('error', { source: event.filename, target: event.lineno })
+      sampleRUM('error', { source: event.filename, target: event.lineno });
 });
 
 window.addEventListener('load', () => sampleRUM('load'));
 
 document.addEventListener('click', (event) => {
-      sampleRUM('click', { target: sampleRUM.targetselector(event.target), source: sampleRUM.sourceselector(event.target) })
+      sampleRUM('click', { target: sampleRUM.targetselector(event.target), source: sampleRUM.sourceselector(event.target) });
 });
 
 loadPage(document);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -640,17 +640,17 @@ const ICON_ROOT = '/icons';
 sampleRUM('top');
 
 window.addEventListener('unhandledrejection', (event) => {
-      sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });
+  sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });
 });
 
 window.addEventListener('error', (event) => {
-      sampleRUM('error', { source: event.filename, target: event.lineno });
+  sampleRUM('error', { source: event.filename, target: event.lineno });
 });
 
 window.addEventListener('load', () => sampleRUM('load'));
 
 document.addEventListener('click', (event) => {
-      sampleRUM('click', { target: sampleRUM.targetselector(event.target), source: sampleRUM.sourceselector(event.target) });
+  sampleRUM('click', { target: sampleRUM.targetselector(event.target), source: sampleRUM.sourceselector(event.target) });
 });
 
 loadPage(document);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -87,7 +87,6 @@ sampleRUM.mediaobserver = (window.IntersectionObserver) ? new IntersectionObserv
     });
 }, { threshold: 0.25 }) : { observe: () => { } };
 
-
 sampleRUM.observe = ((elements) => {
   elements.forEach((element) => {
     if (element.tagName.toLowerCase() === 'img'
@@ -640,17 +639,17 @@ const ICON_ROOT = '/icons';
 
 sampleRUM('top');
 
-window.addEventListener('unhandledrejection', event => {
-  sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line })
+window.addEventListener('unhandledrejection', (event) => {
+      sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line })
 });
 
-window.addEventListener('error', event => {
-  sampleRUM('error', { source: event.filename, target: event.lineno })
+window.addEventListener('error', (event) => {
+      sampleRUM('error', { source: event.filename, target: event.lineno })
 });
 
 window.addEventListener('load', () => sampleRUM('load'));
 
-document.addEventListener('click', event => {
+document.addEventListener('click', (event) => {
       sampleRUM('click', { target: sampleRUM.targetselector(event.target), source: sampleRUM.sourceselector(event.target) })
 });
 


### PR DESCRIPTION
 - adding missing rum addition sourceselector
 - adding missing rum addition targetselector
 - adding missing rum addition observe
 - adding observe invocations
 - adding missing rum addition mediaobserver
 - adding missing rum addition blockobserver
 - adding event listener for error
 - adding event listener for unhandledrejection

Test URLs
 - before: https://main--helix-project-boilerplate--adobe.hlx.page/?rum=on
 - after:  https://advancedrum--helix-project-boilerplate--adobe.hlx.page/?rum=on

Edits performed by https://github.com/trieloff/helix-codemods/blob/main/transforms/advancedrum.js
