### PR TITLE
chore: ignore the helix-importer-ui folder by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 coverage/*
 logs/*
 node_modules/*
+
+helix-importer-ui


### PR DESCRIPTION
Assuming people will use the importer, the folder needs to be exclude from the project.