### PR TITLE
fix: section metadata leaves an empty div

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -285,7 +285,7 @@ export function decorateSections($main) {
         if (key === 'style') section.classList.add(toClassName(meta.style));
         else section.dataset[toCamelCase(key)] = meta[key];
       });
-      sectionMeta.remove();
+      sectionMeta.parentNode.remove();
     }
   });
 }


### PR DESCRIPTION
Once read, the section metadata block is removed. But its wrapper remains as an empty div in the dom which might cause issues for styling.

Before: https://main--helix-project-boilerplate--adobe.hlx.page/
After: https://section-metadata-empty-div--helix-project-boilerplate--adobe.hlx.page/


