### PR TITLE
fix: nav brand img height

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -40,6 +40,7 @@ header nav .nav-brand p {
 
 header nav .nav-brand img {
   width: 128px;
+  height: auto;
 }
 
 /* hamburger */


### PR DESCRIPTION
Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After: https://nav-brand-img-height--helix-project-boilerplate--adobe.hlx.page/

See https://main--gscouts--hlxsites.hlx.page/index1 an example of the problem:
<img width="285" alt="Screen Shot 2022-09-01 at 10 13 25 AM" src="https://user-images.githubusercontent.com/43383503/187962517-abd8dffe-05f5-4dbd-b88b-01714f01c324.png">
