### PR TITLE
fix(rum): do not send `top` checkpoint twice

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -62,7 +62,6 @@ export function sampleRUM(checkpoint, data = {}) {
           const script = document.createElement('script');
           script.src = 'https://rum.hlx.page/.rum/@adobe/helix-rum-enhancer@^1/src/index.js';
           document.head.appendChild(script);
-          sendPing(data);
           return true;
         },
       };


### PR DESCRIPTION
Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/?rum=on
- After: https://no-double-top--helix-project-boilerplate--adobe.hlx.page/?rum=on

In the before setup, the `top` checkpoint would be sent twice, once from `top` and once from `lazy`

Before:
<img width="1470" alt="Screen Shot 2022-10-24 at 15 49 00" src="https://user-images.githubusercontent.com/39613/197636358-e13834ea-ccc4-4e96-b3d6-82e91fff2118.png">

1. `top`
2. `load`
3. `lazy`
4. `top` (again?)
5. favicon

After:

<img width="1470" alt="Screen Shot 2022-10-24 at 15 49 25" src="https://user-images.githubusercontent.com/39613/197636464-94040b9a-5d85-4075-8cac-1f51698fbc6f.png">

1. `top`
2. `load`
3. `lazy`
4. favicon
5. `viewmedia`