### PR TITLE
fix: icons loading sequence

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -48,7 +48,6 @@ function buildAutoBlocks(main) {
 export function decorateMain(main) {
   // hopefully forward compatible button decoration
   decorateButtons(main);
-  decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
@@ -90,6 +89,8 @@ export function addFavIcon(href) {
 async function loadLazy(doc) {
   const main = doc.querySelector('main');
   await loadBlocks(main);
+
+  decorateIcons(main);
 
   const { hash } = window.location;
   const element = hash ? main.querySelector(hash) : false;


### PR DESCRIPTION
https://icons-loading--helix-project-boilerplate--adobe.hlx.live/

vs. 

https://main--helix-project-boilerplate--adobe.hlx.live/

icons are loaded too early, i think this is a left over from the previous implementation. 
on pages where there are a lot of icons used in main, the current behavior can inflate `LCP` significantly.