### PR TITLE
refactor: lib-franklin.css

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,5 +1,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/scripts/lib-franklin.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
+<link rel="stylesheet" href="/styles/lib-franklin.css"/>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">

--- a/head.html
+++ b/head.html
@@ -1,6 +1,5 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <script src="/scripts/lib-franklin.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
-<link rel="stylesheet" href="/styles/lib-franklin.css"/>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <link rel="icon" href="data:,">

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -60,6 +60,7 @@ export function decorateMain(main) {
 async function loadEager(doc) {
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
+  loadCSS(`${window.hlx.codeBasePath}/styles/lib-franklin.css`);
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -60,7 +60,6 @@ export function decorateMain(main) {
 async function loadEager(doc) {
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
-  loadCSS(`${window.hlx.codeBasePath}/styles/lib-franklin.css`);
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);

--- a/styles/lib-franklin.css
+++ b/styles/lib-franklin.css
@@ -1,4 +1,14 @@
-
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 
 /* progressive body appearance */
 body {

--- a/styles/lib-franklin.css
+++ b/styles/lib-franklin.css
@@ -1,0 +1,21 @@
+
+
+/* progressive body appearance */
+body {
+  display: none;
+}
+
+body.appear {
+  display: unset;
+}
+
+/* progressive section appearance */
+main .section[data-section-status='loading'],
+main .section[data-section-status='initialized'] {
+  display: none;
+}
+
+img {
+  width: auto;
+  height: auto;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -49,11 +49,6 @@ body {
   line-height: 1.6;
   color: var(--text-color);
   background-color: var(--background-color);
-  display: none;
-}
-
-body.appear {
-  display: unset;
 }
 
 header {
@@ -200,8 +195,6 @@ hr {
 
 main img {
   max-width: 100%;
-  width: auto;
-  height: auto;
 }
 
 @media (min-width: 600px) {
@@ -224,12 +217,6 @@ main img {
     max-width: 1200px;
     margin: auto;
   }
-}
-
-/* progressive section appearance */
-main .section[data-section-status='loading'],
-main .section[data-section-status='initialized'] {
-  display: none;
 }
 
 main .section.highlight {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,16 +1,4 @@
-/*
- * Copyright 2020 Adobe. All rights reserved.
- * This file is licensed to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy
- * of the License at http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under
- * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
- * OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
- */
-
- :root {
+:root {
   /* colors */
   --link-color: #035fe6;
   --link-hover-color: #136ff6;


### PR DESCRIPTION
Analog to `scripts.js` and `lib-franklin.js`, move code related to page loading sequence from `styles.css` to a dedicated file `lib-franklin.css` in order to simplify upgrades and better separate product from project code.

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.live/
- After: https://lib-css--helix-project-boilerplate--adobe.hlx.live/