### PR TITLE
chore: fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs/*
 node_modules/*
 
 helix-importer-ui
+.DS_Store

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -527,7 +527,6 @@ export async function waitForLCP(lcpBlocks) {
 /**
  * loads a block named 'header' into header
  */
-
 export function loadHeader(header) {
   const headerBlock = buildBlock('header', '');
   header.append(headerBlock);
@@ -538,7 +537,6 @@ export function loadHeader(header) {
 /**
  * loads a block named 'footer' into footer
  */
-
 export function loadFooter(footer) {
   const footerBlock = buildBlock('footer', '');
   footer.append(footerBlock);
@@ -547,12 +545,12 @@ export function loadFooter(footer) {
 }
 
 /**
- * init block utils
+ * setup block utils
  */
-
-function init() {
+export function setup() {
   window.hlx = window.hlx || {};
   window.hlx.codeBasePath = '';
+  window.hlx.lighthouse = new URLSearchParams(window.location.search).get('lighthouse') === 'on';
 
   const scriptEl = document.querySelector('script[src$="/scripts/scripts.js"]');
   if (scriptEl) {
@@ -563,7 +561,13 @@ function init() {
       console.log(error);
     }
   }
+}
 
+/**
+ * auto init
+ */
+function init() {
+  setup();
   sampleRUM('top');
 
   window.addEventListener('load', () => sampleRUM('load'));

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -3,8 +3,12 @@
 
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
 
+/** @type {import('./types').Scripts} */
 let scripts;
+/** @type {import('./types').LibFranklin} */
+let lib;
 
 document.body.innerHTML = await readFile({ path: './dummy.html' });
 document.head.innerHTML = await readFile({ path: './head.html' });
@@ -12,14 +16,16 @@ document.head.innerHTML = await readFile({ path: './head.html' });
 describe('Core Helix features', () => {
   before(async () => {
     scripts = await import('../../scripts/scripts.js');
+    lib = await import('../../scripts/lib-franklin.js');
+
     document.body.innerHTML = await readFile({ path: './body.html' });
   });
 
   it('Initializes window.hlx', async () => {
     // simulate code base path and turn on lighthouse
-    /* needs fixing
     document.head.appendChild(document.createElement('script')).src = '/foo/scripts/scripts.js';
     window.history.pushState({}, '', `${window.location.href}&lighthouse=on`);
+    lib.setup();
 
     expect(window.hlx.codeBasePath).to.equal('/foo');
     expect(window.hlx.lighthouse).to.equal(true);
@@ -32,7 +38,6 @@ describe('Core Helix features', () => {
     window.hlx.codeBasePath = '';
     window.hlx.lighthouse = false;
     Array.from(document.querySelectorAll('script')).pop().remove();
-    */
   });
 
   it('Adds favicon', async () => {

--- a/test/scripts/types.d.ts
+++ b/test/scripts/types.d.ts
@@ -1,0 +1,5 @@
+import type * as ScriptsModule from '../../scripts/scripts';
+import type * as LibModule from '../../scripts/lib-franklin';
+
+export type Scripts = typeof ScriptsModule;
+export type LibFranklin = typeof LibModule;


### PR DESCRIPTION
fixes the scripts tests by adding an exported `setup` function to lib and setting `window.hlx.lighthouse`

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page
- After: https://fix-tests--helix-project-boilerplate--adobe.hlx.page
