### PR TITLE
Fix CSS linting arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "wtr \"./test/**/*.test.js\" --node-resolve --port=2000 --coverage",
     "test:watch": "npm test -- --watch",
     "lint:js": "eslint .",
-    "lint:css": "stylelint 'blocks/**/*.css' 'styles/*.css'",
+    "lint:css": "stylelint blocks/**/*.css styles/*.css",
     "lint": "npm run lint:js && npm run lint:css"
   },
   "repository": {


### PR DESCRIPTION
when running CSS linting, i get the following error:

```
$ npm run lint:css

> @adobe/helix-project-boilerplate@1.0.0 lint:css
> stylelint 'blocks/**/*.css' 'styles/*.css'

Error: No files matching the pattern "'blocks/**/*.css', 'styles/*.css'" were found.
    at standalone (D:\Develop\github\adobe\helix-project-boilerplate\node_modules\stylelint\lib\standalone.js:260:43)
```

Tested in Environment: Windows with Powershell and Git Bash

https://feature-fix-css-linting--helix-project-boilerplate--stefanseifert.hlx.page/