### PR TITLE
fix: vertical scrollbar disappears on desktop

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -55,7 +55,7 @@ function toggleAllNavSections(sections, expanded = false) {
 function toggleMenu(nav, navSections, forceExpanded = null) {
   const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
   const button = nav.querySelector('.nav-hamburger button');
-  document.body.style.overflowY = expanded ? '' : 'hidden';
+  document.body.style.overflowY = (expanded || MQ.matches) ? '' : 'hidden';
   nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
   toggleAllNavSections(navSections, expanded || MQ.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');


### PR DESCRIPTION
currently, scrollbar will disappear on desktop sizes when the nav is set to "expanded"
now, scrollbar will disappear only when nav is "expanded" on mobile/tablet sizes (previous behavior) 

Fix #161 

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After: https://header-fix--helix-project-boilerplate--adobe.hlx.page/
