### PR TITLE
fix: handle invalid hashes without throwing error

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -92,7 +92,7 @@ async function loadLazy(doc) {
   await loadBlocks(main);
 
   const { hash } = window.location;
-  const element = hash ? main.querySelector(hash) : false;
+  const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
   loadHeader(doc.querySelector('header'));


### PR DESCRIPTION
Fix #167 

Test URLs:
- Before: 

https://main--helix-project-boilerplate--adobe.hlx.page/
https://main--helix-project-boilerplate--adobe.hlx.page/#
https://main--helix-project-boilerplate--adobe.hlx.page/#valid
https://main--helix-project-boilerplate--adobe.hlx.page/#old_hash=&from_ims=true

- After:

https://gh167-scroll-into-view-fix--helix-project-boilerplate--adobe.hlx.page/
https://gh167-scroll-into-view-fix--helix-project-boilerplate--adobe.hlx.page/#
https://gh167-scroll-into-view-fix--helix-project-boilerplate--adobe.hlx.page/#valid
https://gh167-scroll-into-view-fix--helix-project-boilerplate--adobe.hlx.page/#old_hash=&from_ims=true
