### PR TITLE
chore: better nav reload after publish

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -10,7 +10,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   const footerPath = cfg.footer || '/footer';
-  const resp = await fetch(`${footerPath}.plain.html`);
+  const resp = await fetch(`${footerPath}.plain.html`, window.location.pathname.endsWith('/footer') ? { cache: 'reload' } : {});
   const html = await resp.text();
   const footer = document.createElement('div');
   footer.innerHTML = html;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -95,7 +95,7 @@ export default async function decorate(block) {
 
   // fetch nav content
   const navPath = config.nav || '/nav';
-  const resp = await fetch(`${navPath}.plain.html`);
+  const resp = await fetch(`${navPath}.plain.html`, window.location.pathname.endsWith('/nav') ? { cache: 'reload' } : {});
 
   if (resp.ok) {
     const html = await resp.text();


### PR DESCRIPTION
there are some repeated questions related to browser cache after publishing changes to `nav` or `footer`.

here is some simple logic that forces a `reload` of the `.plain.html`

https://main--helix-project-boilerplate--adobe.hlx.live/nav
vs.
https://nav-reload--helix-project-boilerplate--adobe.hlx.live/nav