### PR TITLE
Minor Nav touch-up ideas

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1,4 +1,11 @@
 /* header and nav layout */
+header .nav-wrapper {
+  background-color: var(--background-color);
+  width: 100%;
+  z-index: 2;
+  position: fixed;
+}
+
 header nav {
   box-sizing: border-box;
   display: grid;
@@ -7,15 +14,10 @@ header nav {
     'sections sections sections' 1fr / auto 1fr auto;
   align-items: center;
   gap: 0 2em;
-  position: fixed;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1;
-  width: 100%;
+  margin: auto;
   max-width: 1264px;
   height: var(--nav-height);
   padding: 0 1rem;
-  background-color: var(--background-color);
   font-family: var(--body-font-family);
 }
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,18 +1,18 @@
-import { readBlockConfig, decorateIcons } from '../../scripts/lib-franklin.js';
+import { getMetadata, decorateIcons } from '../../scripts/lib-franklin.js';
 
 // media query match that indicates mobile/tablet width
-const MQ = window.matchMedia('(min-width: 900px)');
+const isDesktop = window.matchMedia('(min-width: 900px)');
 
 function closeOnEscape(e) {
   if (e.code === 'Escape') {
     const nav = document.getElementById('nav');
     const navSections = nav.querySelector('.nav-sections');
     const navSectionExpanded = navSections.querySelector('[aria-expanded="true"]');
-    if (navSectionExpanded && MQ.matches) {
+    if (navSectionExpanded && isDesktop.matches) {
       // eslint-disable-next-line no-use-before-define
       toggleAllNavSections(navSections);
       navSectionExpanded.focus();
-    } else if (!MQ.matches) {
+    } else if (!isDesktop.matches) {
       // eslint-disable-next-line no-use-before-define
       toggleMenu(nav, navSections);
       nav.querySelector('button').focus();
@@ -55,13 +55,13 @@ function toggleAllNavSections(sections, expanded = false) {
 function toggleMenu(nav, navSections, forceExpanded = null) {
   const expanded = forceExpanded !== null ? !forceExpanded : nav.getAttribute('aria-expanded') === 'true';
   const button = nav.querySelector('.nav-hamburger button');
-  document.body.style.overflowY = (expanded || MQ.matches) ? '' : 'hidden';
+  document.body.style.overflowY = (expanded || isDesktop.matches) ? '' : 'hidden';
   nav.setAttribute('aria-expanded', expanded ? 'false' : 'true');
-  toggleAllNavSections(navSections, expanded || MQ.matches ? 'false' : 'true');
+  toggleAllNavSections(navSections, expanded || isDesktop.matches ? 'false' : 'true');
   button.setAttribute('aria-label', expanded ? 'Open navigation' : 'Close navigation');
   // enable nav dropdown keyboard accessibility
   const navDrops = navSections.querySelectorAll('.nav-drop');
-  if (MQ.matches) {
+  if (isDesktop.matches) {
     navDrops.forEach((drop) => {
       if (!drop.hasAttribute('tabindex')) {
         drop.setAttribute('role', 'button');
@@ -77,7 +77,7 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
     });
   }
   // enable menu collapse on escape keypress
-  if (!expanded || MQ.matches) {
+  if (!expanded || isDesktop.matches) {
     // collapse menu on escape press
     window.addEventListener('keydown', closeOnEscape);
   } else {
@@ -90,11 +90,10 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
-  const config = readBlockConfig(block);
   block.textContent = '';
 
   // fetch nav content
-  const navPath = config.nav || '/nav';
+  const navPath = getMetadata('nav') || '/nav';
   const resp = await fetch(`${navPath}.plain.html`);
 
   if (resp.ok) {
@@ -116,7 +115,7 @@ export default async function decorate(block) {
       navSections.querySelectorAll(':scope > ul > li').forEach((navSection) => {
         if (navSection.querySelector('ul')) navSection.classList.add('nav-drop');
         navSection.addEventListener('click', () => {
-          if (MQ.matches) {
+          if (isDesktop.matches) {
             const expanded = navSection.getAttribute('aria-expanded') === 'true';
             toggleAllNavSections(navSections);
             navSection.setAttribute('aria-expanded', expanded ? 'false' : 'true');
@@ -135,10 +134,13 @@ export default async function decorate(block) {
     nav.prepend(hamburger);
     nav.setAttribute('aria-expanded', 'false');
     // prevent mobile nav behavior on window resize
-    toggleMenu(nav, navSections, MQ.matches);
-    MQ.addEventListener('change', () => toggleMenu(nav, navSections, MQ.matches));
+    toggleMenu(nav, navSections, isDesktop.matches);
+    isDesktop.addEventListener('change', () => toggleMenu(nav, navSections, isDesktop.matches));
 
     decorateIcons(nav);
-    block.append(nav);
+    const navWrapper = document.createElement('div');
+    navWrapper.className = 'nav-wrapper';
+    navWrapper.append(nav);
+    block.append(navWrapper);
   }
 }

--- a/test/blocks/header/header.test.js
+++ b/test/blocks/header/header.test.js
@@ -16,7 +16,11 @@ const sleep = async (time = 1000) => new Promise((resolve) => {
   }, time);
 });
 
-const headerBlock = buildBlock('header', [['Nav', '/test/blocks/header/nav']]);
+const headerBlock = buildBlock('header', [[]]);
+const meta = document.createElement('meta');
+meta.setAttribute('name', 'nav');
+meta.content = '/test/blocks/header/nav';
+document.head.append(meta);
 document.querySelector('header').append(headerBlock);
 decorateBlock(headerBlock);
 await loadBlock(headerBlock);


### PR DESCRIPTION
couple of ideas for the nav

https://nav-touchups--helix-project-boilerplate--adobe.hlx.live/
vs.
https://main--helix-project-boilerplate--adobe.hlx.live/


(1) introducing nav wrapper:

<img width="662" alt="Screenshot 2023-02-12 at 3 51 09 PM" src="https://user-images.githubusercontent.com/5289336/218342115-55e4f274-b4f5-4d90-83c5-2ec51bdcaa2d.png">
<img width="656" alt="Screenshot 2023-02-12 at 3 51 34 PM" src="https://user-images.githubusercontent.com/5289336/218342137-0e2d366f-5b88-48b7-a537-a5172430bacb.png">

(2) minor naming proposal:
`MQ` seems a bit generic, i think semantically it would be `isDesktop`

(3) nav config via meta:
somehow we seem to have used block config to specify the nav path, but i don't think that's practical way of doing it, i would propose to use meta instead

(4) bumping z-index:
i think hero (and any other background image situation) should use `z-index` `0` and `1` instead of the current `-1` setup, since that one is not compatible with simple background colors.
