### PR TITLE
Fix display of icons from SVG sprite

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -181,7 +181,7 @@ export async function decorateIcons(element) {
     if (ICONS_CACHE[iconName].styled) {
       parent.innerHTML = ICONS_CACHE[iconName].html;
     } else {
-      parent.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg"><use href="#${iconName}"/></svg>`;
+      parent.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg"><use href="#icons-sprite-${iconName}"/></svg>`;
     }
   });
 }


### PR DESCRIPTION
https://github.com/adobe/helix-project-boilerplate/commit/b478ec34a5d283f475146ad895178f682844e65d introduced an optimized way to handle displaying icons based on SVG sprited. unfortunately the code seems to be broken and icons are mis-referenced in the sprite. (the commit did not contain unit tests, nor was there content to visualize it.)

this PR should fix the problem.

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.live/
- After: https://feature-svg-sprite--helix-project-boilerplate--stefanseifert.hlx.live/
