### PR TITLE
chore: remove extra css for cls protection to script

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -232,12 +232,6 @@ main .section {
   }
 }
 
-/* progressive section appearance */
-main .section[data-section-status='loading'],
-main .section[data-section-status='initialized'] {
-  display: none;
-}
-
 /* section metadata */
 main .section.highlight {
   background-color: var(--highlight-background-color);


### PR DESCRIPTION
we have some CLS protection in styles.css that are a part of lib-franklin and not part of the project.
to separate concerns a little better, i am proposing to move those directly into lib-franklin i think there is a possibly for a FOUC but i would say that possibility has existed before, and some PSI testing may shed some light...

https://cls-to-script--helix-project-boilerplate--adobe.hlx.page/

vs.

https://main--helix-project-boilerplate--adobe.hlx.page/