### PR TITLE
fix: Use .live instead of .page for Pull Requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,5 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--<repo>--<owner>.hlx.page/
-- After: https://<branch>--<repo>--<owner>.hlx.page/
+- Before: https://main--<repo>--<owner>.hlx.live/
+- After: https://<branch>--<repo>--<owner>.hlx.live/


### PR DESCRIPTION
There can be significant variance in the results of the PageSpeed when using the .page endpoint, as it doesn't have caching. To increase the stability of the results switching the template default to use .live.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--<repo>--<owner>.hlx.page/
- After: https://<branch>--<repo>--<owner>.hlx.page/
