### PR TITLE
Use npm 8 or later for build

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - run: npm install
     - run: npm run lint
     - run: npm test


### PR DESCRIPTION
Node 14 comes with npm 6 which only really understands package-lock.json version 1. Builds will try to interpret version 2, but often fail. Build logs say as much. Using node 16 or later uses npm 8 which seems to fail less frequently. For someone just starting out with the boiler plate and using a recent node version, they may find it hard to work out why their build fails at npm install on a PR, but works perfectly locally.  This should fix the problem. Fixed it for me.

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.live/ 
- After: https://patch-1--helix-project-boilerplate--ieb.hlx.live/

