### PR TITLE
chore: re-add body hiding to css

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -68,6 +68,7 @@ async function loadEager(doc) {
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);
+    document.body.classList.add('appear');
     await waitForLCP(LCP_BLOCKS);
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -60,6 +60,11 @@ body {
   line-height: 1.6;
   color: var(--text-color);
   background-color: var(--background-color);
+  display: none;
+}
+
+body.appear {
+  display: unset;
 }
 
 header {


### PR DESCRIPTION
it looks like the script only solution produces a `FOUC` on certain devices... moving back the `body.appear` based protection for the time being.

https://main--helix-project-boilerplate--adobe.hlx.live/
vs.
https://cls-to-script--helix-project-boilerplate--adobe.hlx.live/

before:
<img width="522" alt="image" src="https://user-images.githubusercontent.com/5289336/226129911-fe62122d-6cd4-48b4-84de-2b962197ea4e.png">

after:
<img width="535" alt="image" src="https://user-images.githubusercontent.com/5289336/226129887-2f68b897-b14a-414c-9802-f5c1b4ed3782.png">
