### PR TITLE
Use npm 8 or later to avoid build failures due to package lock versions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '16' #required for npm 8 or later.
     - run: npm install
     - run: npm run lint
     - run: npm test

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - run: npm install
     - run: npm run lint
     - run: npm test


### PR DESCRIPTION
Use npm 8 or later for the builds by using node 16

Fix #198

URL for testing:

- https://patch-1--helix-project-boilerplate--phi-x-174.hlx.page/
