### PR TITLE
fix(rum): do not submit URL parameters to RUM collection

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -47,7 +47,7 @@ export function sampleRUM(checkpoint, data = {}) {
         path: () => window.location.pathname,
       };
       // eslint-disable-next-line object-curly-newline, max-len
-      window.hlx.rum = { weight, id, random, isSelected, sampleRUM, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'full'] };
+      window.hlx.rum = { weight, id, random, isSelected, sampleRUM, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'] };
     }
     const { weight, id } = window.hlx.rum;
     if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {


### PR DESCRIPTION
BREAKING CHANGE: the default behavior of RUM collection is now to omit URL parameters. To restore the old behavior set `window.hlx.RUM_MASK_URL = 'full'`

- After: https://trieloff-patch-2--helix-project-boilerplate--adobe.hlx.page/?rum=on
