### PR TITLE
chore: refactor loadCSS, add loadScript

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -82,19 +82,41 @@ export function sampleRUM(checkpoint, data = {}) {
  * Loads a CSS file.
  * @param {string} href The path to the CSS file
  */
-export function loadCSS(href, callback) {
-  if (!document.querySelector(`head > link[href="${href}"]`)) {
-    const link = document.createElement('link');
-    link.setAttribute('rel', 'stylesheet');
-    link.setAttribute('href', href);
-    if (typeof callback === 'function') {
-      link.onload = (e) => callback(e.type);
-      link.onerror = (e) => callback(e.type);
+export async function loadCSS(href) {
+  return new Promise((resolve, reject) => {
+    if (!document.querySelector(`head > link[href="${href}"]`)) {
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      link.onload = resolve;
+      link.onerror = reject;
+      document.head.append(link);
+    } else {
+      resolve();
     }
-    document.head.appendChild(link);
-  } else if (typeof callback === 'function') {
-    callback('noop');
-  }
+  });
+}
+
+/**
+ * Loads a non module JS file.
+ * @param {string} href The path to the CSS file
+ * @param {Object} attrs additional optional attributes
+ */
+
+export async function loadScript(url, attrs) {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    if (attrs) {
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+      for (const attr in attrs) {
+        script.setAttribute(attr, attrs[attr]);
+      }
+    }
+    script.onload = resolve;
+    script.onerror = reject;
+    document.head.append(script);
+  });
 }
 
 /**
@@ -399,9 +421,7 @@ export async function loadBlock(block) {
     block.dataset.blockStatus = 'loading';
     const { blockName } = block.dataset;
     try {
-      const cssLoaded = new Promise((resolve) => {
-        loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`, resolve);
-      });
+      const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
       const decorationComplete = new Promise((resolve) => {
         (async () => {
           try {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -80,7 +80,7 @@ export function sampleRUM(checkpoint, data = {}) {
 
 /**
  * Loads a CSS file.
- * @param {string} href The path to the CSS file
+ * @param {string} href URL to the CSS file
  */
 export async function loadCSS(href) {
   return new Promise((resolve, reject) => {
@@ -99,23 +99,27 @@ export async function loadCSS(href) {
 
 /**
  * Loads a non module JS file.
- * @param {string} href The path to the CSS file
+ * @param {string} src URL to the JS file
  * @param {Object} attrs additional optional attributes
  */
 
-export async function loadScript(url, attrs) {
+export async function loadScript(src, attrs) {
   return new Promise((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = url;
-    if (attrs) {
-    // eslint-disable-next-line no-restricted-syntax, guard-for-in
-      for (const attr in attrs) {
-        script.setAttribute(attr, attrs[attr]);
+    if (!document.querySelector(`head > script[src="${src}"]`)) {
+      const script = document.createElement('script');
+      script.src = src;
+      if (attrs) {
+      // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        for (const attr in attrs) {
+          script.setAttribute(attr, attrs[attr]);
+        }
       }
+      script.onload = resolve;
+      script.onerror = reject;
+      document.head.append(script);
+    } else {
+      resolve();
     }
-    script.onload = resolve;
-    script.onerror = reject;
-    document.head.append(script);
   });
 }
 


### PR DESCRIPTION
this is an attempt to modernize `loadCSS()` and add `loadScript()`
for loadCSS this is a breaking change, input is very welcome...

i lifted a lot of the `loadScript()` code from @synox 

https://load-css-script--helix-project-boilerplate--adobe.hlx.live/
vs.
https://main--helix-project-boilerplate--adobe.hlx.live/