### PR TITLE
fix: rescope icon identifiers to avoid clashing references across icons

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -182,7 +182,11 @@ export async function decorateIcons(element) {
           return;
         }
         // Styled icons don't play nice with the sprite approach because of shadow dom isolation
-        const svg = await response.text();
+        let svg = await response.text();
+        // rescope ids and references to avoid clashes across icons
+        svg = svg
+          .replaceAll(/ id="([^"]+)"/g, (_, id) => ` id="${iconName}-${id}"`)
+          .replaceAll(/="url\(#(\w+)\)"/g, (_, id) => `="url(#${iconName}-${id})"`);
         if (svg.match(/(<style | class=)/)) {
           ICONS_CACHE[iconName] = { styled: true, html: svg };
         } else {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -182,13 +182,16 @@ export async function decorateIcons(element) {
           return;
         }
         // Styled icons don't play nice with the sprite approach because of shadow dom isolation
-        let svg = await response.text();
-        // rescope ids and references to avoid clashes across icons
-        svg = svg
-          .replaceAll(/ id="([^"]+)"/g, (_, id) => ` id="${iconName}-${id}"`)
-          .replaceAll(/="url\(#(\w+)\)"/g, (_, id) => `="url(#${iconName}-${id})"`);
-        if (svg.match(/(<style | class=)/)) {
-          ICONS_CACHE[iconName] = { styled: true, html: svg };
+        // and same for internal references
+        const svg = await response.text();
+        if (svg.match(/(<style | class=|url\(#[^)]+\))/)) {
+          ICONS_CACHE[iconName] = {
+            styled: true,
+            html: svg
+              // rescope ids and references to avoid clashes across icons;
+              .replaceAll(/ id="([^"]+)"/g, (_, id) => ` id="${iconName}-${id}"`)
+              .replaceAll(/="url\(#(\w+)\)"/g, (_, id) => `="url(#${iconName}-${id})"`),
+          };
         } else {
           ICONS_CACHE[iconName] = {
             html: svg


### PR DESCRIPTION
Icons that use internal references of the form `url(#…)` to reference groups or specific elements for stuff like gradients or filters have a high risk of clashing when all inlined in the same document. Also, this kind of reference does not work well with the `<use/>` tag.

This PR will thus handle those icons the same way as styled icons and just inline them instead of adding those to the icon sprite, and we also scope the identifiers to the icon name to avoid clashes.


Fix #235

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After: https://issue235--helix-project-boilerplate--ramboz.hlx.page/
