### PR TITLE
chore: fix cards to be autoblocking / fragment compatible

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -5,7 +5,7 @@ export default function decorate(block) {
   const ul = document.createElement('ul');
   [...block.children].forEach((row) => {
     const li = document.createElement('li');
-    li.innerHTML = row.innerHTML;
+    while (row.firstElementChild) li.append(row.firstElementChild);
     [...li.children].forEach((div) => {
       if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
       else div.className = 'cards-card-body';


### PR DESCRIPTION
replacing the `.innerHTML` is incompatible with the block loader as it removes the elements that were referenced as blocks. this becomes particularly visible during autoblocking eg. fragments.

https://fragment-compatible-cards--helix-project-boilerplate--adobe.hlx.page/

vs.

https://main--helix-project-boilerplate--adobe.hlx.page/

