### PR TITLE
feat: add capability to patch block config at runtime

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -430,7 +430,7 @@ export function buildBlock(blockName, content) {
 
 /**
  * Gets the configuration for the given glock, and also passes
- * the config to the `patchBlockConfig` methods in the plugins.
+ * the config throw all custom patching helpes added to the project.
  *
  * @param {Element} block The block element
  * @returns {object} The block config (blockName, cssPath and jsPath)

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -429,11 +429,11 @@ export function buildBlock(blockName, content) {
 }
 
 /**
- * Gets the configuration for the given glock, and also passes
- * the config throw all custom patching helpes added to the project.
+ * Gets the configuration for the given block, and also passes
+ * the config through all custom patching helpers added to the project.
  *
  * @param {Element} block The block element
- * @returns {object} The block config (blockName, cssPath and jsPath)
+ * @returns {Object} The block config (blockName, cssPath and jsPath)
  */
 function getBlockConfig(block) {
   const { blockName } = block.dataset;

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -440,8 +440,10 @@ function getBlockConfig(block) {
   const cssPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`;
   const jsPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`;
   const original = { blockName, cssPath, jsPath };
-  return window.hlx.patchBlockConfig.reduce(
-    (config, fn) => (typeof fn === 'function' ? fn(config, original) : config) || config,
+  return window.hlx.patchBlockConfig
+    .filter((fn) => typeof fn === 'function')
+    .reduce(
+    (config, fn) => fn(config, original),
     { blockName, cssPath, jsPath },
   );
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -441,7 +441,7 @@ function getBlockConfig(block) {
   const jsPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`;
   const original = { blockName, cssPath, jsPath };
   return window.hlx.patchBlockConfig.reduce(
-    (config, fn) => (typeof fn === 'function' ? fn(config, original) : config),
+    (config, fn) => (typeof fn === 'function' ? fn(config, original) : config) || config,
     { blockName, cssPath, jsPath },
   );
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -443,9 +443,9 @@ function getBlockConfig(block) {
   return window.hlx.patchBlockConfig
     .filter((fn) => typeof fn === 'function')
     .reduce(
-    (config, fn) => fn(config, original),
-    { blockName, cssPath, jsPath },
-  );
+      (config, fn) => fn(config, original),
+      { blockName, cssPath, jsPath },
+    );
 }
 
 /**

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -429,6 +429,24 @@ export function buildBlock(blockName, content) {
 }
 
 /**
+ * Gets the configuration for the given glock, and also passes
+ * the config to the `patchBlockConfig` methods in the plugins.
+ *
+ * @param {Element} block The block element
+ * @returns {object} The block config (blockName, cssPath and jsPath)
+ */
+function getBlockConfig(block) {
+  const { blockName } = block.dataset;
+  const cssPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`;
+  const jsPath = `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`;
+  const original = { blockName, cssPath, jsPath };
+  return window.hlx.patchBlockConfig.reduce(
+    (config, fn) => (typeof fn === 'function' ? fn(config, original) : config),
+    { blockName, cssPath, jsPath },
+  );
+}
+
+/**
  * Loads JS and CSS for a block.
  * @param {Element} block The block element
  */
@@ -436,13 +454,13 @@ export async function loadBlock(block) {
   const status = block.dataset.blockStatus;
   if (status !== 'loading' && status !== 'loaded') {
     block.dataset.blockStatus = 'loading';
-    const { blockName } = block.dataset;
+    const { blockName, cssPath, jsPath } = getBlockConfig(block);
     try {
-      const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
+      const cssLoaded = loadCSS(cssPath);
       const decorationComplete = new Promise((resolve) => {
         (async () => {
           try {
-            const mod = await import(`../blocks/${blockName}/${blockName}.js`);
+            const mod = await import(jsPath);
             if (mod.default) {
               await mod.default(block);
             }
@@ -644,6 +662,7 @@ export function setup() {
   window.hlx.RUM_MASK_URL = 'full';
   window.hlx.codeBasePath = '';
   window.hlx.lighthouse = new URLSearchParams(window.location.search).get('lighthouse') === 'on';
+  window.hlx.patchBlockConfig = [];
 
   const scriptEl = document.querySelector('script[src$="/scripts/scripts.js"]');
   if (scriptEl) {


### PR DESCRIPTION
We've had several cases in the past where we needed to override the default block config logic when loading blocks:
- experimentations may load from a different folder name, or load a different js/css file in the same block folder
- themes that were loading alternate CSS files for block variants

To make maintaining those downstream projects easier, I propose to directly add an extension mechanism so we have fewer modifications to the `lib-franklin.js` file.

Test URLs:
- Before: https://main--helix-project-boilerplate--adobe.hlx.page/
- After:
  - https://extend-block-config--helix-project-boilerplate--ramboz.hlx.page/ (regular page not using the extension mechanism)
  - https://main--franklin-experience-decisioning--ramboz.hlx.page/experiments/control (page with experimentation using the extension mechanism)

Sample usage: https://github.com/ramboz/franklin-experience-decisioning/blob/main/scripts/experience-decisioning/index.js#L359-L417