### PR TITLE
feat: enable listeners to all RUM events, not just the sampled ones

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -28,6 +28,8 @@ export function sampleRUM(checkpoint, data = {}) {
         .filter(({ fnname }) => dfnname === fnname)
         .forEach(({ fnname, args }) => sampleRUM[fnname](...args));
     });
+  sampleRUM.always = sampleRUM.always || [];
+  sampleRUM.always.on = (chkpnt, fn) => { sampleRUM.always[chkpnt] = fn; };
   sampleRUM.on = (chkpnt, fn) => { sampleRUM.cases[chkpnt] = fn; };
   defer('observe');
   defer('cwv');
@@ -72,6 +74,7 @@ export function sampleRUM(checkpoint, data = {}) {
       };
       sendPing(data);
       if (sampleRUM.cases[checkpoint]) { sampleRUM.cases[checkpoint](); }
+      if (sampleRUM.always[checkpoint]) { sampleRUM.always[checkpoint](data); }
     }
   } catch (error) {
     // something went wrong


### PR DESCRIPTION
Enables listeners to all RUM events, not just the sampled ones.

Using RUM for instrumentation and forwarding the RUM events of interest to WebSDK client-side depends on this feature being present in the boilerplate code.
Same is applicable for conversion tracking using RUM https://github.com/adobe/franklin-rum-conversion/tree/main and then forwarding the conversion events to Analytics via WebSDK.

Code changes could not be extracted to an isolated library/file as the logic resides in the sampleRUM method and there is no extension point available atm.

Already used for:
- BambooHR: https://github.com/BambooHR/bamboohr-website/blob/main/scripts/scripts.js#L158-L160
- WKND: https://github.com/hlxsites/wknd/pull/22/files#diff-a5ee87ff9063f921ba01933977e6164e5729551986030f0ed7eb747bcffb740fR73

Will also be used next for:
- https://github.com/hlxsites/24petwatch
- https://github.com/hlxsites/petplace
- https://github.com/hlxsites/bitdefender
- https://github.com/hlxsites/realmadrid

Test URLs:
- Before: https://main--helix-project-boilerplate--iuliag.hlx.page/
- After: https://samplerum-always--helix-project-boilerplate--iuliag.hlx.page/