### PR TITLE
fix: sampleRUM always for checkpoint to be called even if RUM not selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/*
 helix-importer-ui
 .DS_Store
 *.bak
+.idea

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -74,8 +74,8 @@ export function sampleRUM(checkpoint, data = {}) {
       };
       sendPing(data);
       if (sampleRUM.cases[checkpoint]) { sampleRUM.cases[checkpoint](); }
-      if (sampleRUM.always[checkpoint]) { sampleRUM.always[checkpoint](data); }
     }
+    if (sampleRUM.always[checkpoint]) { sampleRUM.always[checkpoint](data); }
   } catch (error) {
     // something went wrong
   }


### PR DESCRIPTION
Fix https://github.com/adobe/helix-project-boilerplate/pull/247 where the `sampleRUM.always[checkpoint]` is still called inside the if for RUM selected events

Test URLs:
- Before: https://main--helix-project-boilerplate--iuliag.hlx.page/
- After: https://fix-samplerum-always--helix-project-boilerplate--iuliag.hlx.page/
