### PR TITLE
chore: change display to block instead of unset

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -72,7 +72,7 @@ body {
 }
 
 body.appear {
-  display: unset;
+  display: block;
 }
 
 header {


### PR DESCRIPTION
`unset` on `<body>` seems to result in `inline` which is a bit unexpected for `<body>` and may yield side-effects.

https://main--helix-project-boilerplate--adobe.hlx.live/
vs.
https://body-block--helix-project-boilerplate--adobe.hlx.live/
