### PR TITLE
Issue #262 - decorateIcons accessibility improvements for lighthouse

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -223,7 +223,14 @@ export async function decorateIcons(element) {
 
   icons.forEach((span) => {
     const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
-    const parent = span.firstElementChild?.tagName === 'A' ? span.firstElementChild : span;
+    let parent;
+    if (span.firstElementChild?.tagName === 'A') {
+      parent = span.firstElementChild;
+      parent.setAttribute('aria-label', iconName);
+    } else {
+      parent = span;
+      if (parent.parentNode.tagName === 'A') parent.parentNode.setAttribute('aria-label', iconName);
+    }
     // Styled icons need to be inlined as-is, while unstyled ones can leverage the sprite
     if (ICONS_CACHE[iconName].styled) {
       parent.innerHTML = ICONS_CACHE[iconName].html;


### PR DESCRIPTION
Submitting this PR for review to add functionality to improve lighthouse score when SVG icons are linked.  The issue is documented here - https://github.com/adobe/helix-project-boilerplate/issues/262  

Fix #262

Test URLs:
- Before: https://main--franklin-demo--dave-fink.hlx.live/icons-link-issue
- After: https://svg-icon-link-issue--franklin-demo--dave-fink.hlx.live/icons-link-issue
