### PR TITLE
feat: sync to block collection

### DIFF
--- a/.github/workflows/cleanup-on-create.yaml
+++ b/.github/workflows/cleanup-on-create.yaml
@@ -23,9 +23,11 @@ jobs:
         with:
           node-version: 24
       - name: Remove Helper Files
-        run: | 
+        run: |
           rm -rf \
             .github/workflows/cleanup-on-create.yaml \
+            .github/workflows/sync-block-collection.yaml \
+            sync-block-collection.sh \
             .renovaterc.json \
             CHANGELOG.md
 

--- a/.github/workflows/sync-block-collection.yaml
+++ b/.github/workflows/sync-block-collection.yaml
@@ -1,0 +1,15 @@
+name: Sync to aem-block-collection
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # never run in a repo derived from this template — only the canonical source
+    if: github.repository == 'adobe/aem-boilerplate'
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./sync-block-collection.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.BLOCK_COLLECTION_SYNC_TOKEN }}

--- a/sync-block-collection.sh
+++ b/sync-block-collection.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+ORG=adobe
+REPO=aem-block-collection
+FILES=(scripts/aem.js scripts/scripts.js head.html)
+SHA=$(git rev-parse --short HEAD)
+BRANCH=sync-boilerplate-$SHA
+
+cd ..
+echo "Using gh version: $(gh --version)"
+gh repo clone $ORG/$REPO
+for f in "${FILES[@]}"; do
+  cp "aem-boilerplate/$f" "$REPO/$f"
+done
+
+cd $REPO
+
+echo "Creating branch $BRANCH"
+git checkout -b $BRANCH
+git add "${FILES[@]}"
+
+if git diff --cached --quiet; then
+  echo "No drift detected — skipping PR"
+  exit 0
+fi
+
+echo "Committing changes"
+git commit -m "chore: sync scripts/aem.js, scripts/scripts.js, head.html from aem-boilerplate@$SHA
+
+Source: https://github.com/$ORG/aem-boilerplate/commit/$SHA
+"
+
+echo "Ready to create PR"
+gh repo set-default $ORG/$REPO
+
+git remote add token-authed-github https://${GITHUB_TOKEN}@github.com/$ORG/$REPO
+
+echo "Successfully added remote"
+
+echo git push --set-upstream token-authed-github $BRANCH
+git push --set-upstream token-authed-github $BRANCH
+echo gh pr create -f --head $BRANCH --base main
+gh pr create -f --head $BRANCH --base main


### PR DESCRIPTION
## Why

[`aem-block-collection`](https://github.com/adobe/aem-block-collection) doesn't stay in sync with `aem-boilerplate` the way `aem-boilerplate` stays in sync with [`aem-lib`](https://github.com/adobe/aem-lib), requiring manually pulling in the latest changes.

## What this does

Adds a GitHub Action to `aem-boilerplate` that, on every push to `main`, checks whether `scripts/aem.js`, `scripts/scripts.js`, or `head.html` changed. 
- If so, it opens a PR against `aem-block-collection` with those files updated (the same pattern `aem-lib` already uses to keep `aem-boilerplate`'s `scripts/aem.js` current, just one repo further downstream). 
- If none of those files changed, nothing happens.

The scope is intentionally narrow: just the three files that have actually caused drift and regressions so far. It doesn't touch blocks or docs and it's guarded so it can never accidentally run in a project someone creates from this template (only in `adobe/aem-boilerplate` itself).

## Before this goes live

- A repo secret needs to be added to `adobe/aem-boilerplate`. 
- A manual test run (`workflow_dispatch`) against a real past commit before letting it run unattended on every push, just to confirm the PR it opens looks right.
- Confirm scope. Right now it's just these three files, not the shared blocks (`cards`, `header`, `hero`, etc.), since block-collection may have intentionally diverged some of those.

## Test URLs:
- Before: https://main--aem-boilerplate--adobe.aem.live/
- After: https://sync-block-collection--aem-boilerplate--adobe.aem.live/
